### PR TITLE
feat: Update response payload of leads endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -71,8 +71,8 @@ app.get("/v1/users/:id/leads", (request: Request, response: Response) => {
     data = faker.datatype.array(itemsAmount).map(() => {
       const firstName = faker.name.firstName();
       const lastName = faker.name.lastName();
-      const registeredAt = faker.date.past(undefined, new Date());
-      const expiresAt = faker.date.future(undefined, new Date());
+      const registeredAt = faker.date.past();
+      const expiresAt = faker.date.future();
       const openedAt = faker.date.between(registeredAt, expiresAt); 
 
       let lead: any = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,10 +68,12 @@ app.get("/v1/users/:id/leads", (request: Request, response: Response) => {
   const isValidUser = isUserProducer || isUserLeader;
 
   if (isValidUser) {
-    data = Array(itemsAmount).fill(0).map(() => {
+    data = faker.datatype.array(itemsAmount).map(() => {
       const firstName = faker.name.firstName();
       const lastName = faker.name.lastName();
-      const openedAt = faker.date.past(undefined, new Date()); 
+      const registeredAt = faker.date.past(undefined, new Date());
+      const expiresAt = faker.date.future(undefined, new Date());
+      const openedAt = faker.date.between(registeredAt, expiresAt); 
 
       let lead: any = {
         id: faker.datatype.uuid(),
@@ -81,8 +83,8 @@ app.get("/v1/users/:id/leads", (request: Request, response: Response) => {
         },
         campaignId: faker.datatype.number({ min: 1, max: 10 }),
         status: faker.random.arrayElement(statusArray),
-        registeredAt: faker.date.past(undefined, openedAt),
-        expiresAt: faker.date.future(undefined, new Date())
+        registeredAt,
+        expiresAt
       };
 
       if (isUserProducer) {
@@ -106,7 +108,7 @@ app.get("/v1/users/:id/leads", (request: Request, response: Response) => {
           },
           managerId: faker.datatype.uuid(),
           distributionType: faker.random.arrayElement(distributionTypeArray),
-          openedAt
+          openedAt: faker.random.arrayElement([openedAt, null])
         };
       }
 


### PR DESCRIPTION
## Descrição

Alteração na lógica de resposta do endpoint `/v1/users/:id/leads` para retornar aleatoriamente leads com data de abertura e leads sem data de abertura.